### PR TITLE
add opengraph metadata for KIPs

### DIFF
--- a/app/kips/[slug]/page.tsx
+++ b/app/kips/[slug]/page.tsx
@@ -23,6 +23,8 @@ const KipDraft = (props: any) => {
   const post = getKipContent(slug);
   return (
     <div>
+      <meta property="og:title" content={`KIP-${post.data.kip}: ${post.data.title}`}/>
+			<meta property="og:description" content={post.content.split("## Abstract")[0]} />
       <article className="prose max-w-none font-mono prose-code:text-yellow-800 prose-pre:bg-gray-100">
         <h1 className="pt-4">
           KIP-{post.data.kip}: {post.data.title}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added Open Graph metadata to the Kwenta State Log for KIPs, which includes the KIP's number and title, and the summary.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Kwenta/kwenta-state-log/issues/37

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against dev environment with a Localhost Opengraph Checker

## Screenshots
<img width="623" alt="Screenshot 2023-07-11 at 14 58 06" src="https://github.com/Kwenta/kwenta-state-log/assets/123545417/3d0a0015-6934-43e1-888e-d3df554c6d0b">