### PR TITLE
Enh/add opengraph metadata

### DIFF
--- a/app/kips/[slug]/page.tsx
+++ b/app/kips/[slug]/page.tsx
@@ -24,7 +24,7 @@ const KipDraft = (props: any) => {
   return (
     <div>
       <meta property="og:title" content={`KIP-${post.data.kip}: ${post.data.title}`}/>
-			<meta property="og:description" content={post.content.split("## Abstract")[0]} />
+			<meta property="og:description" content={post.content.split("## Abstract")[0].split("##")[1]} />
       <article className="prose max-w-none font-mono prose-code:text-yellow-800 prose-pre:bg-gray-100">
         <h1 className="pt-4">
           KIP-{post.data.kip}: {post.data.title}

--- a/app/kips/[slug]/page.tsx
+++ b/app/kips/[slug]/page.tsx
@@ -23,6 +23,8 @@ const KipDraft = (props: any) => {
   const post = getKipContent(slug);
   return (
     <div>
+      <meta property="og:title" content={`KIP-${post.data.kip}: ${post.data.title}`}/>
+			<meta property="og:description" content={post.content.split("## Abstract")[0]} />
       <article className="prose max-w-none font-mono prose-code:text-yellow-800 prose-pre:bg-gray-100">
         <h1 className="pt-4">
           KIP-{post.data.kip}: {post.data.title}


### PR DESCRIPTION
Related to https://github.com/Kwenta/kwenta-state-log/pull/40

Small fix who removes ## Before the Simple Summary title.


<img width="610" alt="Screenshot 2023-07-20 at 16 01 58" src="https://github.com/Kwenta/kwenta-state-log/assets/123545417/df4ef48b-6ba4-48b8-8ce7-bea45ef1cf42">
