### PR TITLE
Added dark mode using localStorage

### DIFF
--- a/app/kips/[slug]/page.tsx
+++ b/app/kips/[slug]/page.tsx
@@ -25,7 +25,7 @@ const KipDraft = (props: any) => {
     <div>
       <meta property="og:title" content={`KIP-${post.data.kip}: ${post.data.title}`}/>
 			<meta property="og:description" content={post.content.split("## Abstract")[0].split("##")[1]} />
-      <article className="prose max-w-none font-mono prose-code:text-yellow-800 prose-pre:bg-gray-100">
+      <article className="prose dark:prose-invert max-w-none font-mono prose-code:text-yellow-800 prose-pre:bg-gray-100 dark:prose-code:text-yellow-800 dark:prose-pre:bg-gray-900">
         <h1 className="pt-4">
           KIP-{post.data.kip}: {post.data.title}
         </h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,16 @@
 import Link from "next/link";
 import "../styles/global.css";
+import ThemeLink from "@/components/ThemeLink";
+
+function presetTheme() {
+  const dark = localStorage.getItem("theme") === "dark";
+
+  if (dark) {
+      document.body.classList.add("dark");
+  }
+}
+
+const themeScript = `(() => { ${presetTheme.toString()}; presetTheme() })()`;
 
 export const metadata = {
   title: "Kwenta State Log",
@@ -16,19 +27,19 @@ export default function RootLayout({
       <div className="flex flex-row border-b-2 border-yellow-800 pb-4 pr-8 pt-8">
         <div className="basis-1/2">
           <Link href="/">
-            <h1 className="font-mono md:text-3xl text-black text-lg">Kwenta State Log</h1>
+            <h1 className="font-mono md:text-3xl dark:text-white text-black dark:text-white text-lg">Kwenta State Log</h1>
           </Link>
-          <p className="font-mono text-black text-xs md:text-base">
+          <p className="font-mono text-black dark:text-white text-xs md:text-base">
             A living document defining the state of Kwenta
           </p>
         </div>
         <div className="basis-1/2 text-sm md:text-base">
-          <p className="text-right font-mono text-black hover:underline">
+          <p className="text-right font-mono text-black dark:text-white hover:underline">
             <Link className="space-x-3" href="/">
               Kwenta State Log
             </Link>
           </p>
-          <p className="text-right font-mono text-black hover:underline">
+          <p className="text-right font-mono text-black dark:text-white hover:underline">
             <Link href="/all-kips">Kwenta Improvement Proposals</Link>
           </p>
         </div>
@@ -37,7 +48,7 @@ export default function RootLayout({
   );
 
   const footer = (
-    <footer className="border-t-2 border-yellow-800 pb-4 pr-8 pt-8 text-left font-mono text-black">
+    <footer className="border-t-2 border-yellow-800 pb-4 pr-8 pt-8 text-left font-mono text-black dark:text-white">
       <div>
         The Kwenta State Log (KSL) is a living document which defines the state
         of Kwenta. Amendments and additions can be made to the KSL via a{" "}
@@ -69,6 +80,13 @@ export default function RootLayout({
         >
           Kwenta Improvement Proposals
         </Link>
+        . Toggle{" "}
+        <ThemeLink
+          href=""
+          className="font-mono text-yellow-800 hover:underline"
+        >
+          dark mode
+        </ThemeLink>
         .
       </div>
       <div className="pt-4">
@@ -79,7 +97,7 @@ export default function RootLayout({
         >
           CC0
         </Link>
-        . This document was last edited on May 29, 2023. Based on work by
+        . This document was last edited on August 15, 2023. Based on work by
         different members of the Kwenta community.
       </div>
     </footer>
@@ -87,6 +105,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <script dangerouslySetInnerHTML={{ __html: themeScript, }} />
         <div className="mx-auto px-4">
           {header}
           {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -97,7 +97,7 @@ export default function RootLayout({
         >
           CC0
         </Link>
-        . This document was last edited on August 15, 2023. Based on work by
+        . This document was last edited on August 30, 2023. Based on work by
         different members of the Kwenta community.
       </div>
     </footer>

--- a/app/sections/[slug]/page.tsx
+++ b/app/sections/[slug]/page.tsx
@@ -22,11 +22,9 @@ const Section = (props: any) => {
   const slug = props.params.slug;
   const post = getSectionContent(slug);
   return (
-    <p>
-      <article className="prose m-4 max-w-none font-mono prose-h1:mb-1">
-        <Markdown>{post.content}</Markdown>
-      </article>
-    </p>
+    <article className="prose dark:prose-invert m-4 max-w-none font-mono prose-h1:mb-1">
+      <Markdown>{post.content}</Markdown>
+    </article>
   );
 };
 

--- a/components/KipPreview.tsx
+++ b/components/KipPreview.tsx
@@ -3,7 +3,7 @@ import { KipMetadata } from "./KipMetadata";
 
 const PostPreview = (props: KipMetadata) => {
   return (
-    <div className="m-4 border-2 border-dotted border-black p-2 pl-4 text-black">
+    <div className="m-4 border-2 border-dotted border-black dark:border-white p-2 pl-4 text-black dark:text-white">
       <Link href={`/kips/${props.slug}`}>
         <h2 className="font-mono hover:underline">
           KIP-{props.kip}: {props.title}

--- a/components/SectionPreview.tsx
+++ b/components/SectionPreview.tsx
@@ -3,7 +3,7 @@ import { SectionMetadata } from "./SectionMetadata";
 
 const SectionPreview = (props: SectionMetadata) => {
   return (
-    <div className="m-4 text-black">
+    <div className="m-4 text-black dark:text-white">
       <Link href={`/sections/${props.slug}`}>
         <h2 className="font-mono hover:underline">
           {props.slug}. {props.title}

--- a/components/ThemeLink.tsx
+++ b/components/ThemeLink.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import Link, { LinkProps } from 'next/link';
+import { HTMLProps, FC } from 'react';
+
+const toggleTheme = (e: any) => {
+  e.preventDefault();
+  const element = document.body;
+  document.getElementById("theme-toggle-dark-icon")?.classList.toggle("hidden");
+  document.getElementById("theme-toggle-light-icon")?.classList.toggle("hidden");
+  const result = element.classList.toggle("dark");
+  localStorage.setItem('theme', result ? 'dark' : 'light');
+}
+
+const ThemeLink: FC<LinkProps & HTMLProps<HTMLAnchorElement>> = ({
+  children, href, className
+}) => (
+  <Link
+    href={href}
+    className={className}
+    onClick={toggleTheme}
+  >
+    {children}
+  </Link>
+);
+
+export default ThemeLink;

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body.dark {
+    background-color: black;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       typography: {


### PR DESCRIPTION
This branch adds dark mode to the Kwenta State Log using `localStorage`. In the footer there is a "Toggle dark mode" link/button which turns it on/off.

Notes on the implementation:
* When dark mode is turned on `body` gets a `class="dark"` attribute, which Tailwind knows from the config `darkMode: 'class'`. It also persists the on-state to `localStorage`.
* Most places have gotten their own `dark:text-white` or similar dark mode class while articles for Markdown use `dark:prose-invert`.
* To enable flicker-free dark mode the `localStorage` entry is read using a script in the `layout.tsx` file as early as possible.
  * A caveat of this approach is that when developing you get a hydration warning in your console ("Warning: Extra attributes from the server: class") when dark mode is enabled and you load the site.
* I removed a `<p>` around an `<article>` at one place, because it is invalid HTML and triggered some errors in development environment.
* `ThemeLink.tsx` is just a dynamic link to look similar to regular links but use `onClick` for a function call.